### PR TITLE
Fix bug of tokeId loss

### DIFF
--- a/balances.js
+++ b/balances.js
@@ -44,7 +44,13 @@ module.exports.createBalances = async data => {
       continue;
     }
 
-    const tokenIds = value.deposits.filter(x => !value.withdrawals.includes(x));
+    const tokenIds = value.deposits;
+    value.withdrawals.forEach(withdrawal => {
+      const tokenIdIndex = tokenIds.indexOf(withdrawal);
+      if (tokenIdIndex < 0) return;
+
+      tokenIds.splice(tokenIdIndex, 1);
+    });
 
     closingBalances.push({
       wallet: key,


### PR DESCRIPTION
A bug, which caused looses of tokenIds when one wallet gained the same token for the second (third, etc.) time.
E.g. if wallet A transfered token to wallet B and then B returned token back to A.